### PR TITLE
Add description for create secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,6 @@ jobs:
         node-version: 10.x
     - name: generate .env files
       run: |
-        echo -e ${{ secrets.FIREBASE_ENV_SETTINGS }}
         echo -e ${{ secrets.FIREBASE_ENV_SETTINGS }} > .env
     - name: npm ci
       run: npm ci

--- a/README.md
+++ b/README.md
@@ -38,3 +38,22 @@ npm run lint
 
 ### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).
+
+## GitHub Actions settings
+
+### Secret
+
+- FIREBASE_TOKEN
+  ```
+  firebase login:ci > FIREBASE_TOKEN
+  ```
+- FIREBASE_ENV_SETTINGS
+  ```
+  const fs = require('fs');
+  
+  const content = fs.readFileSync('.env.production.local').toString('utf8');
+  const secret = content.replace(/\n/gi, '\\n');
+  console.log(secret);
+
+  // sample: VUE_APP_API_KEY="test"\nVUE_APP_ABC="ABC"\nVUE_APP_...
+  ```


### PR DESCRIPTION
closes #34 

- GitHub Actions で使用する secret 情報の出力手順を README に記載
- 動作確認用のデバッグ出力コードを削除